### PR TITLE
Mapping of ElementDefinition/Usages; fixes #16

### DIFF
--- a/DEHCapellaAdapter/src/App/App.java
+++ b/DEHCapellaAdapter/src/App/App.java
@@ -39,7 +39,9 @@ import DstController.DstController;
 import DstController.IDstController;
 import HubController.IHubController;
 import MappingRules.ComponentToElementMappingRule;
+import MappingRules.ElementToComponentMappingRule;
 import MappingRules.RequirementToRequirementsSpecificationMappingRule;
+import MappingRules.RequirementsSpecificationToRequirementMappingRule;
 import Services.CapellaLog.CapellaLogService;
 import Services.CapellaLog.ICapellaLogService;
 import Services.CapellaSelection.CapellaSelectionService;
@@ -161,7 +163,9 @@ public class App extends AbstractUIPlugin
             AppContainer.Container.addComponent(ISiriusSessionManagerWrapper.class, SiriusSessionManagerWrapper.class);
 
             AppContainer.Container.addComponent(ComponentToElementMappingRule.class.getName(), ComponentToElementMappingRule.class);
+            AppContainer.Container.addComponent(ElementToComponentMappingRule.class.getName(), ElementToComponentMappingRule.class);
             AppContainer.Container.addComponent(RequirementToRequirementsSpecificationMappingRule.class.getName(), RequirementToRequirementsSpecificationMappingRule.class);
+            AppContainer.Container.addComponent(RequirementsSpecificationToRequirementMappingRule.class.getName(), RequirementsSpecificationToRequirementMappingRule.class);
             
             AppContainer.Container.addComponent(IElementDefinitionImpactViewViewModel.class, ElementDefinitionImpactViewViewModel.class);
             AppContainer.Container.addComponent(IRequirementImpactViewViewModel.class, RequirementImpactViewViewModel.class);

--- a/DEHCapellaAdapter/src/DstController/IDstController.java
+++ b/DEHCapellaAdapter/src/DstController/IDstController.java
@@ -29,13 +29,18 @@ import java.util.function.Predicate;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.business.api.session.Session;
 import org.polarsys.capella.core.data.capellacore.CapellaElement;
+import org.polarsys.capella.core.data.information.Unit;
+import org.polarsys.capella.core.data.information.datatype.DataType;
+import org.polarsys.capella.core.data.information.datatype.PhysicalQuantity;
 
 import Enumerations.MappingDirection;
 import Reactive.ObservableCollection;
 import Services.MappingEngineService.IMappableThingCollection;
 import Utils.Ref;
 import ViewModels.Rows.MappedElementRowViewModel;
+import cdp4common.commondata.DefinedThing;
 import cdp4common.commondata.Thing;
+import cdp4common.sitedirectorydata.MeasurementScale;
 import io.reactivex.Observable;
 
 /**
@@ -138,7 +143,6 @@ public interface IDstController extends IDstControllerBase
      */
     <TElement extends CapellaElement> boolean TryGetElementBy(Predicate<? super CapellaElement> predicate, Ref<TElement> refElement);
     
-
     /**
      * Tries to get the corresponding element that has the provided Id
      * 
@@ -148,4 +152,24 @@ public interface IDstController extends IDstControllerBase
      * @return a value indicating whether the {@linkplain CapellaElement} has been found
      */
     <TElement extends CapellaElement> boolean TryGetElementById(String elementId, Ref<TElement> refElement);
+    
+    /**
+     * Tries to get the corresponding element based on the provided {@linkplain DefinedThing} name or short name. 
+     * 
+     * @param <TElement> the type of {@linkplain CapellaElement} to query
+     * @param thing the {@linkplain DefinedThing} that can potentially match a {@linkplain #TElement} 
+     * @param refElement the {@linkplain Ref} of {@linkplain #TElement}
+     * @return a value indicating whether the {@linkplain CapellaElement} has been found
+     */
+    <TElement extends CapellaElement> boolean TryGetElementByName(DefinedThing thing, Ref<TElement> refElement);
+
+    /**
+     * Tries to get a {@linkplain DataType} that matches the provided {@linkplain MeasurementScale}
+     * 
+     * @param scale the {@linkplain MeasurementScale} of reference
+     * @param referenceElement a {@linkplain CapellaElement} that will point to the right session
+     * @param refDataType the {@linkplain Ref} of {@linkplain DataType}
+     * @return a {@linkplain boolean}
+     */
+    boolean TryGetDataType(MeasurementScale scale, CapellaElement referenceElement, Ref<DataType> refDataType);
 }

--- a/DEHCapellaAdapter/src/MappingRules/ComponentToElementMappingRule.java
+++ b/DEHCapellaAdapter/src/MappingRules/ComponentToElementMappingRule.java
@@ -88,7 +88,6 @@ import cdp4common.types.ValueArray;
  */
 public class ComponentToElementMappingRule extends DstToHubBaseMappingRule<CapellaComponentCollection, ArrayList<MappedElementDefinitionRowViewModel>>
 {
-
     /**
      * The string that indicates the language code for the {@linkplain Definition}
      * That contains the Capella Id of the mapped {@linkplain CapellaElement}
@@ -124,7 +123,7 @@ public class ComponentToElementMappingRule extends DstToHubBaseMappingRule<Capel
     private List<Triple<ComponentPort, MappedElementDefinitionRowViewModel, ElementUsage>> portsToConnect = new ArrayList<>();
     
     /**
-     * Initializes a new {@linkplain BlockDefinitionMappingRule}
+     * Initializes a new {@linkplain ComponentToElementMappingRule}
      * 
      * @param hubController the {@linkplain IHubController}
      * @param mappingConfiguration the {@linkplain ICapellaMappingConfigurationService}
@@ -184,7 +183,6 @@ public class ComponentToElementMappingRule extends DstToHubBaseMappingRule<Capel
         this.MapInterfaces();
     }
     
-
     /**
      * Creates the {@linkplain BinaryRelationShip} that connects ports between each others
      * 

--- a/DEHCapellaAdapter/src/MappingRules/DstToHubBaseMappingRule.java
+++ b/DEHCapellaAdapter/src/MappingRules/DstToHubBaseMappingRule.java
@@ -26,22 +26,16 @@ package MappingRules;
 import static Utils.Operators.Operators.AreTheseEquals;
 import static Utils.Stereotypes.StereotypeUtils.GetShortName;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.UUID;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.polarsys.capella.core.data.capellacore.CapellaElement;
 
-import Enumerations.MappingDirection;
+import DstController.IDstController;
 import HubController.IHubController;
 import Services.MappingConfiguration.ICapellaMappingConfigurationService;
-import Services.MappingEngineService.MappingRule;
 import Utils.Ref;
-import ViewModels.Rows.MappedElementRowViewModel;
 import cdp4common.commondata.ClassKind;
-import cdp4common.commondata.NamedThing;
 import cdp4common.commondata.Thing;
 import cdp4common.engineeringmodeldata.ElementDefinition;
 import cdp4common.sitedirectorydata.CategorizableThing;
@@ -58,7 +52,7 @@ import cdp4dal.operations.TransactionContextResolver;
  * @param <TOutput> the output type the rule will return
  */
 public abstract class DstToHubBaseMappingRule<TInput extends Object, TOutput> extends CapellaBaseMappingRule<TInput, TOutput>
-{    
+{
     /**
      * Initializes a new {@linkplain DstToHubBaseMappingRule}
      * 

--- a/DEHCapellaAdapter/src/MappingRules/ElementToComponentMappingRule.java
+++ b/DEHCapellaAdapter/src/MappingRules/ElementToComponentMappingRule.java
@@ -1,0 +1,617 @@
+/*
+ * ElementToComponentMappingRule.java
+ *
+ * Copyright (c) 2020-2022 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
+ *
+ * This file is part of DEH-Capella
+ *
+ * The DEH-Capella is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-Capella is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package MappingRules;
+
+import static Utils.Operators.Operators.AreTheseEquals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.eclipse.sirius.business.api.session.Session;
+import org.polarsys.capella.common.ef.command.AbstractReadWriteCommand;
+import org.polarsys.capella.common.helpers.TransactionHelper;
+import org.polarsys.capella.core.data.capellacore.CapellaElement;
+import org.polarsys.capella.core.data.capellacore.NamedElement;
+import org.polarsys.capella.core.data.cs.Component;
+import org.polarsys.capella.core.data.information.Property;
+import org.polarsys.capella.core.data.information.Unit;
+import org.polarsys.capella.core.data.information.datatype.DataType;
+import org.polarsys.capella.core.data.information.datatype.PhysicalQuantity;
+import org.polarsys.capella.core.data.information.datavalue.DataValue;
+import org.polarsys.capella.core.data.information.datavalue.LiteralBooleanValue;
+import org.polarsys.capella.core.data.information.datavalue.LiteralNumericValue;
+import org.polarsys.capella.core.data.information.datavalue.LiteralStringValue;
+import org.polarsys.capella.core.data.la.LogicalComponent;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.core.data.pa.PhysicalComponentNature;
+import org.polarsys.capella.core.data.requirement.RequirementsPkg;
+
+import App.AppContainer;
+import DstController.IDstController;
+import Enumerations.MappingDirection;
+import HubController.IHubController;
+import Services.CapellaSession.ICapellaSessionService;
+import Services.MappingConfiguration.ICapellaMappingConfigurationService;
+import Utils.Ref;
+import Utils.ValueSetUtils;
+import Utils.Stereotypes.CapellaComponentCollection;
+import Utils.Stereotypes.CapellaTypeEnumerationUtility;
+import Utils.Stereotypes.HubElementCollection;
+import Utils.Stereotypes.RequirementType;
+import Utils.Stereotypes.StereotypeUtils;
+import ViewModels.Rows.MappedElementDefinitionRowViewModel;
+import cdp4common.commondata.DefinedThing;
+import cdp4common.engineeringmodeldata.ElementBase;
+import cdp4common.engineeringmodeldata.ElementDefinition;
+import cdp4common.engineeringmodeldata.ElementUsage;
+import cdp4common.engineeringmodeldata.InterfaceEndKind;
+import cdp4common.engineeringmodeldata.ParameterOrOverrideBase;
+import cdp4common.engineeringmodeldata.RequirementsSpecification;
+import cdp4common.sitedirectorydata.BooleanParameterType;
+import cdp4common.sitedirectorydata.Category;
+import cdp4common.sitedirectorydata.MeasurementScale;
+import cdp4common.sitedirectorydata.MeasurementUnit;
+import cdp4common.sitedirectorydata.QuantityKind;
+import cdp4common.sitedirectorydata.TextParameterType;
+
+/**
+ * The {@linkplain ElementToComponentMappingRule} is the mapping rule implementation for transforming Capella {@linkplain Component} to {@linkplain ElementDefinition}
+ */
+public class ElementToComponentMappingRule extends HubToDstBaseMappingRule<HubElementCollection, ArrayList<MappedElementDefinitionRowViewModel>>
+{    
+    /**
+     * The {@linkplain ICapellaSessionService}
+     */
+    private final ICapellaSessionService sessionService;
+
+    /**
+     * The {@linkplain HubElementCollection} of {@linkplain MappedElementDefinitionRowViewModel}
+     */
+    private HubElementCollection elements;
+    
+    /**
+     * The {@linkplain Collection} of {@linkplain Component} that were created during this mapping
+     */
+    private Collection<? extends Component> temporaryComponents = new ArrayList<>();
+
+    /**
+     * The {@linkplain Collection} of {@linkplain DataType} that were created during this mapping
+     */
+    private Collection<DataType> temporaryDataTypes = new ArrayList<>();
+
+    /**
+     * The {@linkplain Collection} of {@linkplain Unit} that were created during this mapping
+     */
+    private Collection<Unit> temporaryUnits = new ArrayList<>();
+    
+    /**
+     * An {@linkplain Component} of reference that links the current mapping with the correct {@linkplain Session}.
+     * Typically a {@linkplain ProjectElement}
+     */
+    private Component referenceElement;
+
+    /**
+     * Initializes a new {@linkplain ElementToComponentMappingRule}
+     * 
+     * @param hubController the {@linkplain IHubController}
+     * @param mappingConfiguration the {@linkplain ICapellaMappingConfigurationService}
+     * @param sessionService the {@linkplain ICapellaSessionService}
+     * @param dstController the {@linkplain IDstController}
+     */
+    public ElementToComponentMappingRule(IHubController hubController, ICapellaMappingConfigurationService mappingConfiguration, ICapellaSessionService sessionService)
+    {
+        super(hubController, mappingConfiguration);
+        this.sessionService = sessionService;
+    }
+    
+    /**
+     * Transforms an {@linkplain CapellaComponentCollection} of {@linkplain Component} to an {@linkplain ArrayList} of {@linkplain ElementDefinition}
+     * 
+     * @param input the {@linkplain CapellaComponentCollection} of {@linkplain Component} to transform
+     * @return the {@linkplain ArrayList} of {@linkplain MappedElementDefinitionRowViewModel}
+     */
+    @Override
+    public ArrayList<MappedElementDefinitionRowViewModel> Transform(Object input)
+    {
+        try
+        {
+            if(this.dstController == null)
+            {
+                this.dstController = AppContainer.Container.getComponent(IDstController.class);
+            }
+            
+            this.elements = this.CastInput(input);
+
+            this.SetReferenceElement();
+            this.Map(this.elements);
+            this.SaveMappingConfiguration(this.elements, MappingDirection.FromDstToHub);
+            return new ArrayList<>(this.elements);
+        }
+        catch (Exception exception)
+        {
+            this.Logger.catching(exception);
+            return new ArrayList<>();
+        }
+        finally
+        {
+            this.temporaryUnits.clear();
+            this.temporaryComponents.clear();
+            this.temporaryDataTypes.clear();
+        }
+    }
+    
+    /**
+     * Sets the {@linkplain CapellaElement} of reference, {@linkplain #referenceElement}
+     */
+    private void SetReferenceElement()
+    {
+        if(this.referenceElement != null)
+        {
+            return;
+        }
+        
+        this.referenceElement = (Component) this.sessionService.GetTopElement(this.sessionService.GetOpenSessions().get(0));
+    }
+
+    /**
+     * Maps the provided collection of {@linkplain ElementBase}
+     * 
+     * @param mappedElementDefinitions the collection of {@linkplain Component} to map
+     */
+    private void Map(HubElementCollection mappedElementDefinitions)
+    {        
+        for (var mappedElement : new ArrayList<MappedElementDefinitionRowViewModel>(mappedElementDefinitions))
+        {
+            if(mappedElement.GetDstElement() == null)
+            {
+                var component = this.GetOrCreateComponent(mappedElement.GetHubElement());
+                mappedElement.SetDstElement(component);
+            }
+            
+            this.MapContainedElement(mappedElement);
+            this.MapProperties(mappedElement.GetHubElement(), mappedElement.GetDstElement());
+        }
+    }
+    
+    /**
+     * Updates the containment information of the provided parent and component
+     * 
+     * @param parent the {@linkplain Component} parent
+     * @param component the {@linkplain Component} child
+     */
+    private void UpdateContainement(Component parent, Component component)
+    {
+        var project = this.sessionService.GetProject(this.sessionService.GetOpenSessions().get(0));
+        
+        TransactionHelper.getExecutionManager(project).execute(new AbstractReadWriteCommand() 
+        {
+            @Override
+            public void run()
+            {
+                try
+                {
+                    if(parent instanceof PhysicalComponent)
+                    {
+                        ((PhysicalComponent)parent).getOwnedPhysicalComponents().add((PhysicalComponent)component);
+                    }
+                    else if(parent instanceof LogicalComponent)
+                    {
+                        ((LogicalComponent)parent).getOwnedLogicalComponents().add((LogicalComponent)component);
+                    }
+                }
+                catch(IllegalStateException exception)
+                {
+                    Logger.catching(exception);
+                }
+            }
+        });
+    }
+    
+    /**
+     * Maps the properties of the provided {@linkplain ElementDefinition}
+     * 
+     * @param hubElement the {@linkplain ElementDefinition} from which the properties are to be mapped
+     * @param component the target {@linkplain Component}
+     */
+    private void MapProperties(ElementDefinition hubElement, Component component)
+    {
+        this.MapProperties(hubElement.getParameter(), component);
+    }
+
+    /**
+     * Maps the properties of the provided {@linkplain ElementUsage}
+     * 
+     * @param hubElement the {@linkplain ElementUsage} from which the properties are to be mapped
+     * @param component the target {@linkplain Component}
+     */
+    private void MapProperties(ElementUsage hubElement, Component component)
+    {
+        var allParametersAndOverrides = hubElement.getElementDefinition().getParameter().stream()
+                .filter(x -> hubElement.getParameterOverride().stream()
+                        .noneMatch(o -> AreTheseEquals(x.getParameterType().getIid(), o.getParameterType().getIid())))
+                .collect(Collectors.toList());
+        
+        this.MapProperties(allParametersAndOverrides, component);
+    }
+    
+    /**
+     * Maps the properties of the provided {@linkplain Collection} of {@linkplain ParameterOrOverrideBase}
+     * 
+     * @param parameters the {@linkplain Collection} of {@linkplain ParameterOrOverrideBase} to map
+     * @param component the target {@linkplain Component}
+     */
+    private void MapProperties(Collection<? extends ParameterOrOverrideBase> parameters, Component component)
+    {
+        for (var parameter : parameters)
+        {
+            var refScale = new Ref<>(DataType.class);
+            var refProperty = new Ref<Property>(Property.class);
+                        
+            if(!TryGetExistingProperty(component, parameter, refProperty))
+            {
+                if(parameter.getScale() != null)
+                {
+                    this.GetOrCreateDataType(parameter.getScale(), component, refScale);
+                }
+                
+                this.CreateProperty(parameter, refProperty, refScale);
+                component.getOwnedFeatures().add(refProperty.Get());
+            }
+            else if(refProperty.Get().getType() instanceof PhysicalQuantity)
+            {
+                refScale.Set((PhysicalQuantity)refProperty.Get().getType());
+            }
+            
+            this.UpdateValue(parameter, refProperty, refScale);
+        }
+    }
+
+    /**
+     * Get or creates the {@linkplain DataType} that matches the provided {@linkplain MeasurementScale}
+     * 
+     * @param scale the {@linkplain MeasurementScale} to map
+     * @param component the target {@linkplain Component}
+     * @param refScale the {@linkplain Ref} of {@linkplain DataType} that will contains the output {@linkplain DataType}
+     */
+    private void GetOrCreateDataType(MeasurementScale scale, Component component, Ref<DataType> refScale)
+    {
+        this.QueryCollectionByNameAndShortName(scale, this.temporaryDataTypes, refScale);
+        
+        if(!refScale.HasValue() && !this.dstController.TryGetDataType(scale, this.referenceElement, refScale))
+        {
+            var newDataType = StereotypeUtils.InitializeCapellaElement(PhysicalQuantity.class);
+            newDataType.setName(scale.getName());
+                        
+            if(scale.getUnit() != null)
+            {
+                newDataType.setUnit(this.GetOrCreateUnit(scale.getUnit()));
+            }
+            
+            this.temporaryDataTypes.add(newDataType);
+        }
+    }
+
+    /**
+     * Gets or creates the {@linkplain Unit} that matches the provided {@linkplain MeasurementUnit}
+     * 
+     * @param unit the {@linkplain MeasurementUnit} 
+     * @return a matching {@linkplain Unit}
+     */
+    private Unit GetOrCreateUnit(MeasurementUnit unit)
+    {
+        var refUnit = new Ref<>(Unit.class);        
+
+        this.QueryCollectionByNameAndShortName(unit, this.temporaryUnits, refUnit);
+        
+        if(!refUnit.HasValue() && !this.dstController.TryGetElementByName(unit, refUnit))
+        {
+            var newUnit = StereotypeUtils.InitializeCapellaElement(Unit.class);
+            newUnit.setName(unit.getName());
+            refUnit.Set(newUnit);
+            this.temporaryUnits.add(newUnit);
+        }
+
+        return refUnit.Get();
+    }
+
+    /**
+     * Updates the value of the provided {@linkplain Property}
+     * 
+     * @param parameter the {@linkplain ParameterOrOverrideBase} that contains the values to transfer
+     * @param refProperty the {@linkplain Ref} of {@linkplain Property}
+     * @param refScale the {@linkplain Ref} of {@linkplain DataType}
+     */
+    private void UpdateValue(ParameterOrOverrideBase parameter, Ref<Property> refProperty, Ref<DataType> refScale)
+    {
+        DataValue dataValue;
+        
+        if (refProperty.Get().getOwnedDefaultValue() != null)
+        {
+            dataValue = refProperty.Get().getOwnedDefaultValue();
+        }
+        else
+        {
+            dataValue = this.CreateDataValue(parameter, refScale);
+            refProperty.Get().setOwnedDefaultValue(dataValue);
+        }
+
+        this.UpdateValue(dataValue, parameter, refProperty);
+    }
+    
+    /**
+     * Updates the value of the provided {@linkplain Property}
+     * 
+     * @param dataValue the {@linkplain DataValue}
+     * @param parameter the {@linkplain ParameterOrOverrideBase} that contains the values to transfer
+     * @param refProperty the {@linkplain Ref} of {@linkplain Property} 
+     */
+    private void UpdateValue(DataValue dataValue, ParameterOrOverrideBase parameter, Ref<Property> refProperty)
+    {
+        var value = ValueSetUtils.QueryParameterBaseValueSet(parameter, null, null);
+
+        if(dataValue instanceof LiteralNumericValue)
+        {
+            ((LiteralNumericValue)dataValue).setValue(value.getActualValue().get(0));
+        }
+        else if(dataValue instanceof LiteralBooleanValue)
+        {
+            ((LiteralBooleanValue)dataValue).setValue(Boolean.valueOf(value.getActualValue().get(0)));
+        }
+        else if(dataValue instanceof LiteralStringValue)
+        {
+            ((LiteralStringValue)dataValue).setValue(value.getActualValue().get(0));
+        }
+    }
+
+    /**
+     * Gets the {@linkplain DataValue} class type
+     * 
+     * @param parameter the {@linkplain parameter}
+     * @return a {@linkplain Class} of {@linkplain DataValue}
+     */
+    private Class<? extends DataValue> GetDataValueType(ParameterOrOverrideBase parameter)
+    {
+        if(parameter.getParameterType() instanceof QuantityKind)
+        {
+            return LiteralNumericValue.class;
+        }
+        if(parameter.getParameterType() instanceof BooleanParameterType)
+        {
+            return LiteralBooleanValue.class;
+        }
+        if(parameter.getParameterType() instanceof TextParameterType)
+        {
+            return LiteralStringValue.class;
+        }
+        
+        return null;
+    }
+    
+    /**
+     * Creates the {@linkplain DataValue} based on the provided {@linkplain DataType}
+     * 
+     * @return a {@linkplain DataValue}
+     */
+    private DataValue CreateDataValue(ParameterOrOverrideBase parameter, Ref<DataType> dstDataType)
+    {
+        var valueType = this.GetDataValueType(parameter);
+        
+        DataValue dataValue = null;
+        
+        if(valueType != null)
+        {
+            dataValue = StereotypeUtils.InitializeCapellaElement(valueType);
+            
+            if(dataValue instanceof LiteralNumericValue && dstDataType.HasValue() && dstDataType.Get() instanceof PhysicalQuantity)
+            {
+                ((LiteralNumericValue)dataValue).setUnit(((PhysicalQuantity)dstDataType.Get()).getUnit());
+            }
+        }
+        
+        return dataValue;
+    }
+
+    /**
+     * Creates a {@linkplain Property} based on the provided {@linkplain ParameterOrOverrideBase}
+     * 
+     * @param parameter the {@linkplain ParameterOrOverrideBase}
+     * @param refProperty the {@linkplain Ref} {@linkplain Property}
+     * @param dstDataType the {@linkplain Ref} of {@linkplain DataType}
+     */
+    private void CreateProperty(ParameterOrOverrideBase parameter, Ref<Property> refProperty, Ref<DataType> dstDataType)
+    {
+        var newProperty = StereotypeUtils.InitializeCapellaElement(Property.class);
+        newProperty.setName(parameter.getParameterType().getName());
+        
+        if(parameter.getParameterType() instanceof QuantityKind && dstDataType.HasValue())
+        {
+            newProperty.setAbstractType(dstDataType.Get());
+        }
+        
+        var minimumCardinality = StereotypeUtils.InitializeCapellaElement(LiteralNumericValue.class);
+        minimumCardinality.setValue(Integer.toString(1));
+        newProperty.setOwnedMinCard(minimumCardinality);
+        
+        var maximumCardinality = StereotypeUtils.InitializeCapellaElement(LiteralNumericValue.class);
+        maximumCardinality.setValue(Integer.toString(1));
+        newProperty.setOwnedMaxCard(maximumCardinality);
+        
+        refProperty.Set(newProperty);
+    }
+
+    /**
+     * Tries to get an existing {@linkplain Property} that matches the provided {@linkplain ParameterOrOverrideBase}
+     * 
+     * @param dstElement the {@linkplain Component}
+     * @param parameter the {@linkplain ParameterOrOverrideBase} 
+     * @param refProperty the {@linkplain Ref} of {@linkplain Property}
+     * @return a value indicating whether the {@linkplain Property} could be found
+     */
+    private boolean TryGetExistingProperty(Component dstElement, ParameterOrOverrideBase parameter, Ref<Property> refProperty)
+    {
+        var optionalProperty = dstElement.getContainedProperties().stream()
+                .filter(x -> AreTheseEquals(x.getName(), parameter.getParameterType().getName(), true))
+                .findFirst();
+        
+        if(optionalProperty.isPresent())
+        {
+            refProperty.Set(optionalProperty.get());
+        }
+        
+        return refProperty.HasValue();
+    }
+
+    /**
+     * Maps the contained element of the provided {@linkplain MappedElementDefinitionRowViewModel} dst element
+     * 
+     * @param mappedElement the {@linkplain MappedElementDefinitionRowViewModel}
+     */
+    private void MapContainedElement(MappedElementDefinitionRowViewModel mappedElement)
+    {
+        for (var containedUsage : mappedElement.GetHubElement().getContainedElement().stream()
+                .filter(x -> x.getInterfaceEnd() == InterfaceEndKind.NONE).collect(Collectors.toList()))
+        {
+            MappedElementDefinitionRowViewModel usageDefinitionMappedElement = this.elements.stream()
+                    .filter(x -> AreTheseEquals(x.GetDstElement().getName(), containedUsage.getName(), true))
+                    .findFirst()
+                    .orElseGet(() -> 
+                    {
+                        var newMappedElement = new MappedElementDefinitionRowViewModel(containedUsage.getElementDefinition(),
+                                this.GetOrCreateComponent(containedUsage.getElementDefinition()), MappingDirection.FromHubToDst);
+                        
+                        this.elements.add(newMappedElement);
+                        this.UpdateContainement(mappedElement.GetDstElement(), newMappedElement.GetDstElement());
+                        return newMappedElement;
+                    });
+            
+            this.MapProperties(containedUsage, usageDefinitionMappedElement.GetDstElement());
+
+            this.MapContainedElement(usageDefinitionMappedElement);
+        }        
+    }
+
+    /**
+     * Gets or creates a component based on an {@linkplain ElementDefinition}
+     * 
+     * @param elementDefinition the {@linkplain ElementDefinition}
+     * @return an existing or a new {@linkplain Component}
+     */
+    private Component GetOrCreateComponent(ElementDefinition elementDefinition)
+    {
+        @SuppressWarnings("unchecked")
+        var refComponentType = new Ref<>((Class<Class<? extends Component>>) Component.class.getClass());
+
+        if(!this.TryGetComponentClass(elementDefinition, refComponentType))
+        {
+            refComponentType.Set(PhysicalComponent.class);
+        }
+           
+        return this.GetOrCreateComponent(elementDefinition.getName(), refComponentType.Get());
+    }
+    
+    /**
+     * Gets the {@linkplain RequirementType} based on the {@linkplain Category} applied to the provided {@linkplain cdp4common.engineeringmodeldata.Requirement}
+     * 
+     * @param elementDefinition the {@linkplain ElementDefinition}
+     * @param refComponentType the {@linkplain Ref} of {@linkplain RequirementType}
+     * @return a {@linkplain boolean} indicating whether the {@linkplain RequirementType} is different than the default value
+     */
+    private boolean TryGetComponentClass(ElementDefinition elementDefinition, Ref<Class<? extends Component>>  refComponentType)
+    {
+        for (var category : elementDefinition.getCategory())
+        {
+            var componentType = CapellaTypeEnumerationUtility.ComponentTypeFrom(category.getName());
+
+            if(componentType != null)
+            {
+                refComponentType.Set((Class<? extends Component>) componentType.ClassType());
+                break;
+            }
+        }
+           
+        return refComponentType.HasValue();
+    }
+
+    /**
+     * Gets or creates the {@linkplain RequirementsPkg} that can represent the {@linkplain RequirementsSpecification}
+     * 
+     * @param <TComponent> the type of {@linkplain Component}
+     * @param hubElementName the {@linkplain String} element name in the HUB side
+     * @param componentType the {@linkplain Class} of {@linkplain #TComponent}
+     * @return a {@linkplain RequirementsPkg}
+     */
+    @SuppressWarnings("unchecked")
+    private <TComponent extends Component> TComponent GetOrCreateComponent(String hubElementName, Class<TComponent> componentType)
+    {
+        var refElement = new Ref<>(componentType);
+        
+        var existingComponent = this.temporaryComponents.stream()
+                .filter(x -> AreTheseEquals(((NamedElement) x).getName(), hubElementName, true))
+                .findFirst();
+        
+        if(existingComponent.isPresent())
+        {
+            refElement.Set((TComponent) existingComponent.get());
+        }
+        else
+        {
+            if(!this.dstController.TryGetElementBy(x -> x instanceof NamedElement && 
+                    AreTheseEquals(((NamedElement) x).getName(), hubElementName, true), refElement))
+            {
+                var newComponent = StereotypeUtils.InitializeCapellaElement(componentType);
+                
+                if(newComponent instanceof PhysicalComponent)
+                {
+                    ((PhysicalComponent)newComponent).setNature(PhysicalComponentNature.BEHAVIOR);
+                }
+                
+                newComponent.setName(hubElementName);
+                refElement.Set(newComponent);
+            }
+        }
+        
+        return refElement.Get();
+    }
+    
+    /**
+     * Searches for the provided {@linkplain Collection} for an {@linkplain #TElement} 
+     * where the name could match either the name or short name of the provided {@linkplain DefinedThing}.
+     * If found, it assigns the value to the provided {@linkplain Ref}
+     * 
+     * @param <TElement> the type of {@linkplain NamedElement} to get
+     * @param definedThing the {@linkplain DefinedThing}
+     * @param collection the {@linkplain Collection} of {@linkplain #TElement} to query
+     * @param refElement the {@linkplain Ref} of {@linkplain #TElement}
+     */
+    private <TElement extends NamedElement> void QueryCollectionByNameAndShortName(DefinedThing definedThing, 
+            Collection<? extends TElement> collection, Ref<TElement> refElement)
+    {
+        collection.stream()
+                .filter(x -> AreTheseEquals(x.getName(), definedThing.getName(), true) 
+                        || AreTheseEquals(x.getName(), definedThing.getShortName(), true))
+                .findAny()
+                .ifPresent(x -> refElement.Set(x));
+    }
+}

--- a/DEHCapellaAdapter/src/MappingRules/HubToDstBaseMappingRule.java
+++ b/DEHCapellaAdapter/src/MappingRules/HubToDstBaseMappingRule.java
@@ -23,6 +23,7 @@
  */
 package MappingRules;
 
+import DstController.IDstController;
 import HubController.IHubController;
 import Services.MappingConfiguration.ICapellaMappingConfigurationService;
 
@@ -35,10 +36,16 @@ import Services.MappingConfiguration.ICapellaMappingConfigurationService;
 public abstract class HubToDstBaseMappingRule<TInput extends Object, TOutput> extends CapellaBaseMappingRule<TInput, TOutput>
 {
     /**
-     * Initializes a new {@linkplain HubToDstBaseMappingRule}
+     * The {@linkplain IDstController} instance
+     */
+    IDstController dstController;
+    
+    /**
+     * Initializes a new {@linkplain DstToHubBaseMappingRule}
      * 
      * @param hubController the {@linkplain IHubController}
      * @param mappingConfiguration the {@linkplain IMagicDrawMappingConfigurationService}
+     * @param dstController the {@linkplain IDstController}
      */
     protected HubToDstBaseMappingRule(IHubController hubController, ICapellaMappingConfigurationService mappingConfiguration)
     {

--- a/DEHCapellaAdapter/src/Services/CapellaSession/ICapellaSessionService.java
+++ b/DEHCapellaAdapter/src/Services/CapellaSession/ICapellaSessionService.java
@@ -30,6 +30,10 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.business.api.session.Session;
 import org.polarsys.capella.core.data.capellacore.CapellaElement;
+import org.polarsys.capella.core.data.capellamodeller.Project;
+import org.polarsys.capella.core.data.cs.Component;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.core.model.helpers.BlockArchitectureExt.Type;
 
 import ViewModels.CapellaObjectBrowser.Rows.RootRowViewModel;
 import io.reactivex.Observable;
@@ -81,4 +85,61 @@ public interface ICapellaSessionService
      * @return an {@linkplain Observable} of {@linkplain Session}
      */
     Observable<Session> SessionUpdated();
+
+    /**
+     * Gets the {@linkplain Project} from the {@linkplain Session} that owns the provided {@linkplain CapellaElement}
+     * 
+     * @param referenceElement the {@linkplain CapellaElement} used to search the correct session
+     * @return a {@linkplain CapellaElement}
+     */
+    Project GetProject(CapellaElement referenceElement);
+
+    /**
+     * Gets the top element from the {@linkplain Session} that owns the provided {@linkplain CapellaElement}
+     * 
+     * @param referenceElement the {@linkplain CapellaElement} used to search the correct session
+     * @param architectureType the architecture {@linkplain Type}
+     * @return a {@linkplain CapellaElement}
+     */
+    CapellaElement GetTopElement(CapellaElement referenceElement, Type architectureType);
+
+    /**
+     * Gets the top element from the {@linkplain Session} that owns the provided {@linkplain CapellaElement} in the Physical Architecture package
+     * 
+     * @param referenceElement the {@linkplain CapellaElement} used to search the correct session
+     * @return a {@linkplain CapellaElement}
+     */
+    CapellaElement GetTopElement(CapellaElement referenceElement);
+
+    /**
+     * Gets the top element from the {@linkplain Session} that owns the provided {@linkplain CapellaElement}
+     * 
+     * @param project the {@linkplain Project} used to search the correct session
+     * @param architectureType the architecture {@linkplain Type}
+     * @return a {@linkplain CapellaElement}
+     */
+    Component GetTopElement(Project project, Type architectureType);
+
+    /**
+     * Gets the top element from the provided {@linkplain Session} in the Physical Architecture package
+     * 
+     * @param session the {@linkplain Session}
+     * @return a {@linkplain PhysicalComponent}
+     */
+    PhysicalComponent GetTopElement(Session session);
+
+    /**
+     * Gets the open {@linkplain Session}s
+     * 
+     * @return a {@linkplain List} of {@linkplain Session}
+     */
+    List<Session> GetOpenSessions();
+
+    /**
+     * Gets the {@linkplain Project} element from the provided {@linkplain Session}
+     * 
+     * @param session the {@linkplain Session}
+     * @return a {@linkplain Project} element
+     */
+    Project GetProject(Session session);
 }

--- a/DEHCapellaAdapter/src/Utils/Stereotypes/CapellaTypeEnumerationUtility.java
+++ b/DEHCapellaAdapter/src/Utils/Stereotypes/CapellaTypeEnumerationUtility.java
@@ -1,0 +1,147 @@
+/*
+ * CapellaTypeEnumerationUtility.java
+ *
+ * Copyright (c) 2020-2022 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
+ *
+ * This file is part of DEH-Capella
+ *
+ * The DEH-Capella is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-Capella is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package Utils.Stereotypes;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.polarsys.capella.core.data.capellacore.CapellaElement;
+
+/**
+ * The {@linkplain CapellaTypeEnumerationUtility} is a utility class to help deal with java enumerators {@linkplain RequirementType} and {@linkplain ComponentType}
+ */
+public final class CapellaTypeEnumerationUtility
+{
+    /**
+     * The current class logger
+     */
+    private static final Logger logger = LogManager.getLogger();
+    
+    /**
+     * Initializes a new {@linkplain CapellaTypeEnumerationUtility}, unused
+     */
+    private CapellaTypeEnumerationUtility() { }
+
+    /**
+     * Gets an instance of {@linkplain #TEnum} with the {@linkplain classType} matching the provided {@linkplain Class} 
+     * 
+     * @param <TEnum> the {@linkplain Enum} type to return
+     * @param classType the {@linkplain class} that could match the {@linkplain classType} from one of the possible enumeration value
+     * @return a {@linkplain #TEnum}
+     */
+    @SuppressWarnings("unchecked")
+    public static <TEnum extends Enum<?> & ICapellaTypeEnumeration<?, ?>> TEnum From(Class<? extends CapellaElement> classType)
+    {
+        Function<TEnum[], Optional<TEnum>> result = x -> Arrays.asList(x)
+                .stream()
+                .filter(e -> e.ClassType() == classType)
+                .findFirst();
+        
+        var component = result.apply((TEnum[]) ComponentType.values());
+        
+        if(component.isPresent())
+        {
+            return component.get();
+        }
+        
+        var requirement = result.apply((TEnum[]) RequirementType.values());
+        
+        if(requirement.isPresent())
+        {
+            return requirement.get();
+        }
+        
+        return null;
+    }
+    
+    /**
+     * Gets an instance of {@linkplain ComponentType} from the provided {@linkplain String}
+     * 
+     * @param valueOrLabel a {@linkplain String} that could potentially match the {@linkplain Label} of the enum value
+     * @return a {@linkplain ComponentType}
+     */
+    @SuppressWarnings("finally")
+    public static ComponentType ComponentTypeFrom(String valueOrLabel)
+    {
+        for(var value : ComponentType.values())
+        {
+            if(VerifyEnumerationValue(valueOrLabel, value)) 
+            {
+                return value;
+            }
+        }
+        
+        try
+        {
+            return ComponentType.valueOf(valueOrLabel);
+        }
+        finally
+        {
+            return null;
+        }
+    }
+    
+    /**
+     * Gets an instance of {@linkplain RequirementType} with the provided {@linkplain String}
+     * 
+     * @param valueOrLabel a {@linkplain String} that could potentially match the {@linkplain Label} of the enum value
+     * @return a {@linkplain RequirementType}
+     */
+    @SuppressWarnings("finally")
+    public static RequirementType RequirementTypeFrom(String valueOrLabel)
+    {
+        for(var value : RequirementType.values())
+        {
+            if(VerifyEnumerationValue(valueOrLabel, value)) 
+            {
+                return value;
+            }
+        }
+                
+        try
+        {
+            return RequirementType.valueOf(valueOrLabel);
+        }
+        finally
+        {
+            return null;
+        }
+    }
+
+    /**
+     * Assert that the provided {@linkplain #value} matches the provided {@linkplain #valueOrLabel}
+     * 
+     * @param valueOrLabel a {@linkplain String} that could potentially match the {@linkplain Label} of the enum value
+     * @param value the current {@linkplain ICapellaTypeEnumeration} value
+     * @return a value indicating whether the {@linkplain #value} meets the requirements in order to match the provided {@linkplain #valueOrLabel}
+     */
+    private static boolean VerifyEnumerationValue(String valueOrLabel, ICapellaTypeEnumeration<?, ?> value)
+    {
+        return value.Label().equalsIgnoreCase(valueOrLabel) || (value.ClassType() != null 
+                && value.ClassType().getSimpleName().equalsIgnoreCase(valueOrLabel));
+    }
+}

--- a/DEHCapellaAdapter/src/Utils/Stereotypes/ComponentType.java
+++ b/DEHCapellaAdapter/src/Utils/Stereotypes/ComponentType.java
@@ -1,9 +1,9 @@
 /*
- * RequirementType.java
+ * ComponentType.java
  *
  * Copyright (c) 2020-2022 RHEA System S.A.
  *
- * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski, Antoine Théate
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
  *
  * This file is part of DEH-Capella
  *
@@ -23,41 +23,30 @@
  */
 package Utils.Stereotypes;
 
+import java.util.Arrays;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.polarsys.capella.core.data.capellacore.CapellaElement;
-import org.polarsys.capella.core.data.requirement.*;
+import org.polarsys.capella.core.data.cs.Component;
+import org.polarsys.capella.core.data.la.LogicalComponent;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
 
 /**
- * The {@linkplain RequirementType} is an enumerations of all Capella requirements type
+ * The {@linkplain ComponentType} is an enumerations of all mappable Capella {@linkplain Component} type
  */
-public enum RequirementType implements ICapellaTypeEnumeration<RequirementType, Requirement>
-{    
+public enum ComponentType implements ICapellaTypeEnumeration<ComponentType, Component>
+{
     /**
-     * Represents a {@linkplain SystemNonFunctionalRequirement}
+     * Represents a {@linkplain PhysicalComponent}
      */
-    NonFunctional("Non-Functional", SystemNonFunctionalRequirement.class),
+    Physical("Physical Component", PhysicalComponent.class),
     
     /**
-     * Represents a {@linkplain SystemNonFunctionalInterfaceRequirement}
+     * Represents a {@linkplain LogicalComponent}
      */
-    NonFunctionalInterface("Non-Functional Interface", SystemNonFunctionalInterfaceRequirement.class),
+    Logical("Non-Functional Interface", LogicalComponent.class);
     
-    /**
-     * Represents a {@linkplain SystemFunctionalRequirement}
-     */
-    Functional("Functional", SystemFunctionalRequirement.class),
-    
-    /**
-     * Represents a {@linkplain SystemFunctionalInterfaceRequirement}
-     */
-    FunctionalInterface("Functional Interface", SystemFunctionalInterfaceRequirement.class),
-    
-    /**
-     * Represents a {@linkplain SystemUserRequirement}
-     */
-    User("User Requirement", SystemUserRequirement.class);
-
     /**
      * The current class logger
      */
@@ -66,20 +55,20 @@ public enum RequirementType implements ICapellaTypeEnumeration<RequirementType, 
     /**
      * The {@linkplain Class} represented by this enum value
      */
-    private final Class<? extends Requirement> classType;
+    private final Class<? extends Component> classType;
     
     /**
      * The display-able label that represent this enum value
      */
-    private final String label;
+    public final String label;
     
     /**
-     * Initializes a new {@linkplain RequirementType}
+     * Initializes a new {@linkplain ComponentType}
      * 
      * @param label the label associated to the enumeration value
      * @param classType the class associated to the enumeration value
      */
-    private RequirementType(String label, Class<? extends Requirement> classType)
+    private ComponentType(String label, Class<? extends Component> classType)
     {
         this.label = label;
         this.classType = classType;
@@ -95,14 +84,14 @@ public enum RequirementType implements ICapellaTypeEnumeration<RequirementType, 
     {
         return this.label;
     }
-
+    
     /**
      * Gets the {@linkplain Class} of the instance of the enumeration value
      * 
      * @return a {@linkplain Class} of {@linkplain CapellaElement}
      */
     @Override
-    public Class<? extends Requirement> ClassType()
+    public Class<? extends Component> ClassType()
     {
         return this.classType;
     }

--- a/DEHCapellaAdapter/src/Utils/Stereotypes/ICapellaTypeEnumeration.java
+++ b/DEHCapellaAdapter/src/Utils/Stereotypes/ICapellaTypeEnumeration.java
@@ -1,0 +1,48 @@
+/*
+ * ICapellaTypeEnumeration.java
+ *
+ * Copyright (c) 2020-2022 RHEA System S.A.
+ *
+ * Author: Sam Gerené, Alex Vorobiev, Nathanael Smiechowski 
+ *
+ * This file is part of DEH-Capella
+ *
+ * The DEH-Capella is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * The DEH-Capella is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package Utils.Stereotypes;
+
+import org.polarsys.capella.core.data.capellacore.CapellaElement;
+
+/**
+ * The {@linkplain ICapellaTypeEnumeration} is the interface definition for the {@linkplain ComponentType} and the {@linkplain RequirementType}
+ * @param <TEnum> the type of enumeration that implements this interface
+ * @param <TElement> the type of {@linkplain CapellaElement} the implementing enumeration deals with
+ */
+public interface ICapellaTypeEnumeration<TEnum, TElement extends CapellaElement>
+{
+    /**
+     * Gets the {@linkplain Class} of the instance of the enumeration value
+     * 
+     * @return a {@linkplain Class} of {@linkplain CapellaElement}
+     */
+    Class<? extends TElement> ClassType();
+    
+    /**
+     * Gets the {@linkplain String} display-able label
+     * 
+     * @return a {@linkplain String}
+     */
+    String Label();
+}

--- a/DEHCapellaAdapter/src/Utils/Stereotypes/StereotypeUtils.java
+++ b/DEHCapellaAdapter/src/Utils/Stereotypes/StereotypeUtils.java
@@ -26,7 +26,9 @@ package Utils.Stereotypes;
 import static Utils.Operators.Operators.AreTheseEquals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -42,10 +44,15 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.polarsys.capella.core.data.capellacore.CapellaElement;
 import org.polarsys.capella.core.data.capellacore.NamedElement;
 import org.polarsys.capella.core.data.fa.FaPackage;
+import org.polarsys.capella.core.data.information.InformationPackage;
+import org.polarsys.capella.core.data.information.datatype.DatatypePackage;
+import org.polarsys.capella.core.data.information.datavalue.DatavaluePackage;
 import org.polarsys.capella.core.data.pa.PaPackage;
 import org.polarsys.capella.core.data.requirement.Requirement;
 import org.polarsys.capella.core.data.requirement.RequirementPackage;
 import org.polarsys.capella.core.data.requirement.RequirementsPkg;
+import org.polarsys.capella.core.model.helpers.BlockArchitectureExt.Type;
+import org.polarsys.kitalpha.emde.model.Element;
 
 import Utils.Ref;
 
@@ -142,7 +149,7 @@ public final class StereotypeUtils
                     && parent instanceof RequirementsPkg 
                     && EcoreUtil.isAncestor(parent, child);
         }
-        catch(ClassCastException exception)
+        catch(Exception exception)
         {
             LogManager.getLogger().catching(exception);
             return child.eContainer() == parent; 
@@ -240,23 +247,27 @@ public final class StereotypeUtils
      */
     private static Pair<EClassifier, EFactory> GetEClassAndFactory(String className)
     {
-        Function<EPackage, EClassifier> getClassifierFromClassName = (EPackage ePackage) -> ePackage.getEClassifier(className);
-        
-        var eClass = getClassifierFromClassName.apply(PaPackage.eINSTANCE);
-        var eFactory = PaPackage.eINSTANCE.getEFactoryInstance();
-        
-        if(eClass == null)
+        for (var ePackage : GetEPackages())
         {
-            eClass = getClassifierFromClassName.apply(FaPackage.eINSTANCE);
-            eFactory = FaPackage.eINSTANCE.getEFactoryInstance();
+            var eClass = ePackage.getEClassifier(className);
+            
+            if(eClass != null)
+            {
+                return Pair.of(eClass, ePackage.getEFactoryInstance());
+            }
         }
         
-        if(eClass == null)
-        {
-            eClass = getClassifierFromClassName.apply(RequirementPackage.eINSTANCE);
-            eFactory = RequirementPackage.eINSTANCE.getEFactoryInstance();
-        }
+        return Pair.of(null, null);
+    }
 
-        return Pair.of(eClass, eFactory);
+    /**
+     * Gets a {@linkplain List} of {@linkplain EPackage}s instance
+     * 
+     * @return {@linkplain List} of {@linkplain EPackage}
+     */
+    private static List<EPackage> GetEPackages()
+    {
+        return Arrays.asList(PaPackage.eINSTANCE, FaPackage.eINSTANCE, RequirementPackage.eINSTANCE, 
+                InformationPackage.eINSTANCE, DatavaluePackage.eINSTANCE, DatatypePackage.eINSTANCE);
     }
 }

--- a/DEHCapellaAdapter/src/ViewModels/CapellaImpactViewViewModel.java
+++ b/DEHCapellaAdapter/src/ViewModels/CapellaImpactViewViewModel.java
@@ -147,6 +147,7 @@ public class CapellaImpactViewViewModel extends CapellaObjectBrowserViewModel im
     protected RootRowViewModel ComputeDifferences()
     {
         var rootRowViewModel = (RootRowViewModel) this.browserTreeModel.Value().getRoot();
+        
         try
         {
             for (var mappedElementRowViewModel : this.dstController.GetHubMapResult())
@@ -167,7 +168,7 @@ public class CapellaImpactViewViewModel extends CapellaObjectBrowserViewModel im
             
         return rootRowViewModel;
     }
-        
+
     /**
      * Gets the {@linkplain Thing} by its Iid from the capella sessions
      * 
@@ -186,7 +187,7 @@ public class CapellaImpactViewViewModel extends CapellaObjectBrowserViewModel im
 
         for (var childRowViewModel : childrenCollection)
         {
-            if (AreTheseEquals(childRowViewModel.GetElement().getId(), id))
+            if (childRowViewModel.GetElement() != null && AreTheseEquals(childRowViewModel.GetElement().getId(), id))
             {
                 refElement.Set((ElementRowViewModel<? extends CapellaElement>)childRowViewModel);
                 break;

--- a/DEHCapellaAdapter/src/ViewModels/CapellaObjectBrowser/Rows/RequirementRowViewModel.java
+++ b/DEHCapellaAdapter/src/ViewModels/CapellaObjectBrowser/Rows/RequirementRowViewModel.java
@@ -23,6 +23,7 @@
  */
 package ViewModels.CapellaObjectBrowser.Rows;
 
+import Utils.Stereotypes.CapellaTypeEnumerationUtility;
 import org.polarsys.capella.core.data.requirement.Requirement;
 import Utils.Stereotypes.RequirementType;
 import ViewModels.CapellaObjectBrowser.Interfaces.IElementRowViewModel;
@@ -61,6 +62,6 @@ public class RequirementRowViewModel extends ElementRowViewModel<Requirement>
      */
     public RequirementType GetRequirementType()
     {
-        return RequirementType.From(this.GetElement().getClass());
+        return CapellaTypeEnumerationUtility.From(this.GetElement().getClass());
     }
 }

--- a/DEHCapellaAdapter/src/ViewModels/Rows/MappedElementDefinitionRowViewModel.java
+++ b/DEHCapellaAdapter/src/ViewModels/Rows/MappedElementDefinitionRowViewModel.java
@@ -39,8 +39,7 @@ public class MappedElementDefinitionRowViewModel extends MappedElementRowViewMod
      * @param dstElement the {@linkplain TDstElement} that is at the other end
      * @param mappingDirection the {@linkplain MappingDirection} to which this mapping applies to
      */
-    public MappedElementDefinitionRowViewModel(ElementDefinition thing, Component dstElement,
-            MappingDirection mappingDirection)
+    public MappedElementDefinitionRowViewModel(ElementDefinition thing, Component dstElement, MappingDirection mappingDirection)
     {
         super(thing, ElementDefinition.class, dstElement, mappingDirection);
     }    

--- a/DEHCapellaAdapter/src/ViewModels/TransferControlViewModel.java
+++ b/DEHCapellaAdapter/src/ViewModels/TransferControlViewModel.java
@@ -80,7 +80,11 @@ public class TransferControlViewModel implements ITransferControlViewModel
         this.dstController.GetSelectedDstMapResultForTransfer()
             .Changed()
             .subscribe(x -> this.UpdateNumberOfSelectedThing(this.dstController.CurrentMappingDirection()));
-        
+
+        this.dstController.GetSelectedHubMapResultForTransfer()
+            .Changed()
+            .subscribe(x -> this.UpdateNumberOfSelectedThing(this.dstController.CurrentMappingDirection()));
+
         this.dstController.GetMappingDirection()
             .subscribe(mappingDirection ->
             {

--- a/DEHCapellaAdapter/src/Views/CapellaHubBrowserPanel.java
+++ b/DEHCapellaAdapter/src/Views/CapellaHubBrowserPanel.java
@@ -33,7 +33,7 @@ import Views.ViewParts.BaseViewPart;
 
 /**
  * The {@linkplain CapellaHubBrowserPanel} is the main panel view for the Hub controls like session controls and tree views.
- * This view is meant to be integrated into another container view specific to DST * 
+ * This view is meant to be integrated into another container view specific to DST
  */
 @ExludeFromCodeCoverageGeneratedReport
 public class CapellaHubBrowserPanel extends BaseViewPart<ICapellaHubBrowserPanelViewModel, HubBrowserPanel>

--- a/DEHCapellaAdapter/tests/MappingRules/RequirementsSpecificationToRequirementMappingRuleTestFixture.java
+++ b/DEHCapellaAdapter/tests/MappingRules/RequirementsSpecificationToRequirementMappingRuleTestFixture.java
@@ -99,7 +99,8 @@ class RequirementsSpecificationToRequirementMappingRuleTestFixture
         
         this.SetupElements();
         
-        this.mappingRule = new RequirementsSpecificationToRequirementMappingRule(this.hubController, this.mappingConfigurationService, this.dstController);
+        this.mappingRule = new RequirementsSpecificationToRequirementMappingRule(this.hubController, this.mappingConfigurationService);
+        this.mappingRule.dstController = this.dstController;
     }
     
     @Test
@@ -114,12 +115,12 @@ class RequirementsSpecificationToRequirementMappingRuleTestFixture
         assertEquals(this.requirementsSpecification1.getName(), requirement2Container.getName());
         assertSame(result.get(1).GetDstElement().eContainer(), requirement2Container);
         
-        assertTrue(RequirementType.FunctionalInterface.RequirementClassType.isInstance(result.get(0).GetDstElement()));
-        assertTrue(RequirementType.NonFunctionalInterface.RequirementClassType.isInstance(result.get(1).GetDstElement()));
-        assertTrue(RequirementType.NonFunctional.RequirementClassType.isInstance(result.get(2).GetDstElement()));
-        assertTrue(RequirementType.Functional.RequirementClassType.isInstance(result.get(3).GetDstElement()));
-        assertTrue(RequirementType.NonFunctionalInterface.RequirementClassType.isInstance(result.get(4).GetDstElement()));
-        assertTrue(RequirementType.User.RequirementClassType.isInstance(result.get(5).GetDstElement()));
+        assertTrue(RequirementType.FunctionalInterface.ClassType().isInstance(result.get(0).GetDstElement()));
+        assertTrue(RequirementType.NonFunctionalInterface.ClassType().isInstance(result.get(1).GetDstElement()));
+        assertTrue(RequirementType.NonFunctional.ClassType().isInstance(result.get(2).GetDstElement()));
+        assertTrue(RequirementType.Functional.ClassType().isInstance(result.get(3).GetDstElement()));
+        assertTrue(RequirementType.NonFunctionalInterface.ClassType().isInstance(result.get(4).GetDstElement()));
+        assertTrue(RequirementType.User.ClassType().isInstance(result.get(5).GetDstElement()));
     }
 
     private void SetupElements()

--- a/DEHCapellaAdapter/tests/Services/CapellaSession/CapellaSessionServiceTestFixture.java
+++ b/DEHCapellaAdapter/tests/Services/CapellaSession/CapellaSessionServiceTestFixture.java
@@ -87,7 +87,7 @@ import org.eclipse.sirius.business.api.session.SessionManager;
 
 public class CapellaSessionServiceTestFixture extends CapellaSessionRelatedBaseTestFixture
 {
-    private CapellaSessionService service;
+    private ICapellaSessionService service;
     private ObservableValue<Session> sessionAdded;
     private ObservableValue<Session> sessionRemoved;
     private ObservableValue<Session> sessionUpdated;
@@ -145,7 +145,7 @@ public class CapellaSessionServiceTestFixture extends CapellaSessionRelatedBaseT
                             .GetContainedRows().get(0)).GetContainedRows().get(0))
                             .GetContainedRows().get(1)).GetContainedRows().get(4)).GetRequirementType();
         
-        assertEquals(RequirementType.Undefined, requirementType);
+        assertEquals(null, requirementType);
         assertEquals(StringUtils.EMPTY, requirementType.toString());
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEH-Capella/pulls) open
- [x] I have verified that I am following the DEH-Capella [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEH-Capella/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
- [x] Added a mapping rule to map ElementDefinition and ElementUsages to Capella
- [x] Mapping of MeasurementScale and unit.
- [x] Mapping of Containment (Usages).
- [x] Transfer of Components, Properties and values
<!-- Thanks for contributing to DEH-Capella! -->